### PR TITLE
Fix and improve environment selector

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,40 +7,46 @@ import { CountryProvider } from './context/CountryContext';
 import { CheckoutDetailsPage } from './pages/CheckoutDetailsPage';
 import { CheckoutCompletedPage } from './pages/CheckoutCompletedPage';
 import { CallbackPage } from './pages/CallbackPage';
+import { ReactElement } from 'react';
+import { useEnvironment } from './context/EnvironmentContext';
+import { CriiptoVerifyProvider } from '@criipto/verify-react';
 
-interface AppProps {
-  onToggleEnv: () => void;
-  currentEnvironment: string;
-}
+function App(): ReactElement {
+  const { environment } = useEnvironment();
 
-function App({ onToggleEnv, currentEnvironment }: AppProps) {
+  const domain =
+    environment === 'production' ? 'demos.criipto.id' : 'demos-test.criipto.id';
+
   return (
-    <CountryProvider>
-      <ShoppingCartProvider>
-        <div className="mx-auto min-h-screen lg:max-w-5xl">
-          <Routes>
-            <Route path="/callback" element={<CallbackPage />} />
-            <Route
-              path="/"
-              element={
-                <Home
-                  onToggleEnv={onToggleEnv}
-                  currentEnvironment={currentEnvironment}
-                />
-              }
-            />
-            <Route path="/cart" element={<ShoppingCart />} />
-            <Route path="/cart/checkout" element={<ShoppingCart />} />
-            <Route path="/checkout/details" element={<CheckoutDetailsPage />} />
-            <Route
-              path="/checkout/completed"
-              element={<CheckoutCompletedPage />}
-            />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </div>
-      </ShoppingCartProvider>
-    </CountryProvider>
+    <CriiptoVerifyProvider
+      domain={domain}
+      clientID="urn:demos:cool-delivery-react"
+      redirectUri={`${window.location.origin}/callback?to=${btoa('/invalid_redirect_url')}`}
+      sessionStore={window.sessionStorage}
+      message="Log in to Cool Delivery"
+    >
+      <CountryProvider>
+        <ShoppingCartProvider>
+          <div className="mx-auto min-h-screen lg:max-w-5xl">
+            <Routes>
+              <Route path="/callback" element={<CallbackPage />} />
+              <Route path="/" element={<Home />} />
+              <Route path="/cart" element={<ShoppingCart />} />
+              <Route path="/cart/checkout" element={<ShoppingCart />} />
+              <Route
+                path="/checkout/details"
+                element={<CheckoutDetailsPage />}
+              />
+              <Route
+                path="/checkout/completed"
+                element={<CheckoutCompletedPage />}
+              />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </div>
+        </ShoppingCartProvider>
+      </CountryProvider>
+    </CriiptoVerifyProvider>
   );
 }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,20 +1,16 @@
 import { ToggleEnvironmentModal } from './ToggleEnvironmentModal';
-import { EnvProps } from 'types';
 import { SearchIcon, UserIcon } from './Icon';
 import { Logo } from './Logo';
 import { CountryModal } from './CountryModal';
 
-export default function Header({ onToggleEnv, currentEnvironment }: EnvProps) {
+export default function Header() {
   return (
     <header className="flex flex-row items-center justify-between bg-primary-25 px-4 pt-4">
       <Logo />
       <div className="flex flex-row items-center gap-4">
         <SearchIcon className="h-6 w-6 text-light-blue-800" />
         <UserIcon className="h-6 w-6 text-light-blue-800" />
-        <ToggleEnvironmentModal
-          onToggleEnv={onToggleEnv}
-          currentEnvironment={currentEnvironment}
-        />
+        <ToggleEnvironmentModal />
         <CountryModal />
       </div>
     </header>

--- a/src/components/ToggleEnvironmentModal.tsx
+++ b/src/components/ToggleEnvironmentModal.tsx
@@ -1,12 +1,10 @@
 import { useState } from 'react';
 import { Dialog, DialogBody, Switch } from '@material-tailwind/react';
-import { EnvProps } from 'types';
 import { GearIcon } from './Icon';
+import { useEnvironment } from '../context/EnvironmentContext';
 
-export function ToggleEnvironmentModal({
-  onToggleEnv,
-  currentEnvironment,
-}: EnvProps) {
+export function ToggleEnvironmentModal() {
+  const { environment, toggleEnvironment } = useEnvironment();
   const [open, setOpen] = useState(false);
 
   const handleOpen = () => setOpen(!open);
@@ -25,8 +23,8 @@ export function ToggleEnvironmentModal({
             id="env-toggle"
             label="Production"
             color="indigo"
-            checked={currentEnvironment === 'production'}
-            onChange={onToggleEnv}
+            checked={environment === 'production'}
+            onChange={toggleEnvironment}
           />
         </DialogBody>
       </Dialog>

--- a/src/context/EnvironmentContext.tsx
+++ b/src/context/EnvironmentContext.tsx
@@ -1,10 +1,4 @@
-import {
-  ReactNode,
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-} from 'react';
+import { ReactNode, createContext, useContext, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 export type Environment = 'test' | 'production';

--- a/src/context/EnvironmentContext.tsx
+++ b/src/context/EnvironmentContext.tsx
@@ -1,0 +1,53 @@
+import {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export type Environment = 'test' | 'production';
+
+type EnvironmentContext = {
+  environment: Environment;
+  setEnvironment: (newEnvironment: Environment) => void;
+  toggleEnvironment: () => void;
+};
+
+const EnvironmentContext = createContext({} as EnvironmentContext);
+
+export function useEnvironment() {
+  return useContext(EnvironmentContext);
+}
+
+type EnvironmentProviderProps = {
+  children: ReactNode;
+};
+
+export function EnvironmentProvider({ children }: EnvironmentProviderProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [environment, _setEnvironment] = useState<Environment>(
+    (searchParams.get('environment') as Environment) ?? 'test',
+  );
+
+  const setEnvironment = (newEnvironment: Environment): void => {
+    const newParams = new URLSearchParams(searchParams);
+    newParams.set('environment', newEnvironment);
+    setSearchParams(newParams);
+    _setEnvironment(newEnvironment);
+  };
+
+  const toggleEnvironment = (): void => {
+    setEnvironment(environment !== 'production' ? 'production' : 'test');
+  };
+
+  return (
+    <EnvironmentContext.Provider
+      value={{ environment, setEnvironment, toggleEnvironment }}
+    >
+      {children}
+    </EnvironmentContext.Provider>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,43 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter, useSearchParams } from 'react-router-dom';
-import { CriiptoVerifyProvider } from '@criipto/verify-react';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 import '@fontsource/ibm-plex-sans';
-
-function CriiptoVerifyProviderWrapper() {
-  //const environment = search.get('environment') ?? 'test';
-  const [searchParams, setSearchParams] = useSearchParams();
-  const [environment, setEnvironment] = useState(
-    searchParams.get('environment') ?? 'test',
-  );
-
-  const domain =
-    environment === 'test' ? 'demos-test.criipto.id' : 'demos.criipto.id';
-
-  const handleToggleEnv = () => {
-    setSearchParams((params) => {
-      const newEnvironment =
-        params.get('environment') === 'test' ? 'production' : 'test';
-      params.set('environment', newEnvironment);
-      setEnvironment(newEnvironment);
-      return params;
-    });
-  };
-
-  return (
-    <CriiptoVerifyProvider
-      domain={domain}
-      clientID="urn:demos:cool-delivery-react"
-      redirectUri={`${window.location.origin}/callback?to=${btoa('/invalid_redirect_url')}`}
-      sessionStore={window.sessionStorage}
-      message="Log in to Cool Delivery"
-    >
-      <App onToggleEnv={handleToggleEnv} currentEnvironment={environment} />
-    </CriiptoVerifyProvider>
-  );
-}
+import { EnvironmentProvider } from './context/EnvironmentContext';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
@@ -45,7 +12,9 @@ const root = ReactDOM.createRoot(
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <CriiptoVerifyProviderWrapper />
+      <EnvironmentProvider>
+        <App />
+      </EnvironmentProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,15 +2,11 @@ import Header from '../components/Header';
 import Navbar from '../components/Navbar';
 import ProductList from '../components/ProductList';
 import { productsData } from '../products';
-import { EnvProps } from 'types';
 
-function Home({ onToggleEnv, currentEnvironment }: EnvProps) {
+function Home() {
   return (
     <div className="min-h-screen">
-      <Header
-        onToggleEnv={onToggleEnv}
-        currentEnvironment={currentEnvironment}
-      />
+      <Header />
       <Navbar />
       <ProductList products={productsData.beers} />
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,3 @@
-export interface EnvProps {
-  onToggleEnv: () => void;
-  currentEnvironment: string;
-}
-
 export interface Product {
   id: number;
   volume: string;


### PR DESCRIPTION
# Changes
* Fix not having to click twice on the toggle in order to select "production" (because the initial value went from `null => "test"`, instead of `"test" => "production"`)
* Extract environment state and logic to an "EnvironmentContext"
* Only take environment from the url on initial load to make state more stable (such that the app suddenly doesn't forget the environment due to a page navigation).
* Merge `CriiptoVerifyProviderWrapper` into `App` since there where no more logic left except for picking the domain