### PR TITLE
Fix weird transition state between cart and checkout details after doing age verification by moving clearCart to checkout complete

### DIFF
--- a/src/components/StartCheckoutButton.tsx
+++ b/src/components/StartCheckoutButton.tsx
@@ -103,7 +103,7 @@ function AgeVerificationResult(): ReactElement | null {
 }
 
 function CheckoutButton(): ReactElement | null {
-  const { isCartEmpty, clearCart } = useShoppingCart();
+  const { isCartEmpty } = useShoppingCart();
   const {
     shouldShowAgeVerification,
     hasPerformedAgeVerification,
@@ -111,16 +111,15 @@ function CheckoutButton(): ReactElement | null {
   } = useAgeVerification();
   const { logout } = useCriiptoVerify();
 
-  const to = shouldShowAgeVerification ? '/cart/checkout' : '/checkout/details';
-
   const shouldShow = hasPerformedAgeVerification ? ageVerificationPassed : true;
 
   if (!shouldShow) return null;
 
+  const to = shouldShowAgeVerification ? '/cart/checkout' : '/checkout/details';
+
   const onLinkClick: MouseEventHandler<HTMLAnchorElement> = (evt) => {
     if (!shouldShowAgeVerification) {
       evt.preventDefault();
-      clearCart();
       logout({
         redirectUri: `${window.location.origin}/callback`,
         state: btoa('/checkout/details'),

--- a/src/pages/CheckoutCompletedPage.tsx
+++ b/src/pages/CheckoutCompletedPage.tsx
@@ -1,10 +1,18 @@
-import { ReactElement } from 'react';
+import { ReactElement, useEffect } from 'react';
 import { BoxOpenFullIcon, CheckIcon } from '../components/Icon';
 import { Button } from '../components/Button';
 import { Link } from 'react-router-dom';
 import { ActionsFooter } from '../components/ActionsFooter';
+import { useShoppingCart } from '../context/ShoppingCartContext';
 
 export function CheckoutCompletedPage(): ReactElement {
+  const { clearCart } = useShoppingCart();
+
+  useEffect(() => {
+    clearCart();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <div className="flex min-h-screen flex-col items-center px-5 text-center">
       <header className="mt-[15%] flex flex-col items-center justify-center gap-10 bg-white">


### PR DESCRIPTION
## Changes
* Move the `clearCart` call from the checkout button after age verification to when the user hits the checkout completed page